### PR TITLE
Fix WebSocket proxy header

### DIFF
--- a/entry_point/templates/caleydoapp.in.conf
+++ b/entry_point/templates/caleydoapp.in.conf
@@ -11,6 +11,7 @@ server {
         proxy_buffering off;
         proxy_set_header Host $http_host;
         proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "Upgrade";
         proxy_set_header X-Real-IP $remote_addr;
 
         # Mitigate httpoxy attack (see README for details)


### PR DESCRIPTION
Fixes #4

@sgratzl As described in issue #4 the websocket proxy was not working. I added the missing proxy header. 

I don't know if this setting has an influence on the other Caleydo application, since this template file is used for all applications. If you think it's save to use please merge this PR.

How do I build and deploy this repo as Docker build to AWS?