### PR TITLE
Additional env variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ LABEL maintainer="samuel.gratzl@datavisyn.io"
 RUN apk add --update bash \
   certbot \
   openssl openssl-dev ca-certificates \
-&& rm -rf /var/cache/apk/*
+  && rm -rf /var/cache/apk/*
 
 # forward request and error logs to docker log collector
 RUN ln -sf /dev/stdout /var/log/nginx/access.log
@@ -20,8 +20,10 @@ EXPOSE 443
 
 #copy static page
 COPY landing_page /usr/share/nginx/html
+
 # enable gzip
 COPY *.conf /etc/nginx/conf.d/
+
 # custom entry
 COPY entry_point /phovea/
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,12 @@ This repository contains the Dockerfile for creating the caleydoapp.org landing 
 
 ## Configuration
 
-The ngnix server can be configured using environment variables (ENV).
+The ngnix server can be configured using the following environment variables (ENV):
+
+* [`PHOVEA_ENABLE_SSL_LANDING_PAGE`](#enable-ssl-for-landing-page)
+* [`PHOVEA_APP_*`](#add-phovea-app)
+* [`PHOVEA_APPFORWARD_*`](#add-phovea-app-forward)
+* [`PHOVEA_FORWARD_*`](#add-caleydo-subdomain-forward)
 
 
 ### Enable SSL for landing page

--- a/README.md
+++ b/README.md
@@ -5,7 +5,67 @@ This repository contains the Dockerfile for creating the caleydoapp.org landing 
 ***
 
 <a href="https://caleydo.org"><img src="http://caleydo.org/assets/images/logos/caleydo.svg" align="left" width="200px" hspace="10" vspace="6"></a>
-This repository is part of **[Phovea](http://phovea.caleydo.org/)**, a platform for developing web-based visualization applications. For tutorials, API docs, and more information about the build and deployment process, see the [documentation page](http://caleydo.org/documentation/).
+This repository is part of **[Phovea](http://phovea.caleydo.org/)**, a platform for developing web-based visualization apps. For tutorials, API docs, and more information about the build and deployment process, see the [documentation page](http://caleydo.org/documentation/).
+
+
+## Configuration
+
+The ngnix server can be configured using environment variables (ENV).
+
+
+### Enable SSL for landing page
+
+If the variable `PHOVEA_ENABLE_SSL_LANDING_PAGE` exist a SSL certificate for caleydoapp.org is added. Default: no SSL certificate is added.
+
+
+### Add phovea app
+
+The variable `PHOVEA_APP_*` adds an app to the landing page and creates a ngnix configuration and a SSL certificate for this app automatically.
+
+`PHOVEA_APP_<NAME>=<name>;<domain>;<forward>;<release-channel>`
+
+* `<name>`: Name of the app that is visible in the landing page
+* `<domain>`: Subdomain of the app only (e.g., `lineup`)
+* `<forward>`: Target requests are forwarded to (e.g., `cluster:12345`)
+* `<release-channel>`: Release channel can be `stable`, `daily`, or `development` and is indicated on the landing page
+
+Example: `PHOVEA_APP_LINEUP=LineUp;lineup;cluster:12345;stable`
+
+
+### Add phovea app forward
+
+The variable `PHOVEA_APPFORWARD_*` adds an app to the landing page only. No ngnix configuration and SSL certificate is created.
+
+`PHOVEA_APPFORWARD_<NAME>=<name>;<domain>;<forward>;<release-channel>`
+
+* `<name>`: Name of the app that is visible in the landing page
+* `<domain>`: Subdomain of the app only (e.g., `lineup`)
+* `<forward>`: *Not used*
+* `<release-channel>`: Release channel can be `stable`, `daily`, or `development` and is indicated on the landing page
+
+Example: `PHOVEA_APPFORWARD_LINEUP=LineUp;lineup;cluster:12345;stable`
+
+
+### Add Caleydo subdomain forward
+
+The variable `PHOVEA_FORWARD_*` adds a forward for caleydo.org subdomains.
+
+`PHOVEA_FORWARD_<NAME>=<name>;<domain>;<forward>`
+
+* `<name>`: Name of the forward
+* `<domain>`: Full source domain (e.g., `lineup.caleydo.org`)
+* `<forward>`: Full target domain (e.g., www.caleydo.org/tools/lineup)
+
+**Note**: Do not add a protocol (http or https) to the domains!
+
+Example: `PHOVEA_FORWARD_LINEUP=LineUp;lineup.caleydo.org;www.caleydo.org/tools/lineup`
+
+
+## Build Docker image
+
+Run `docker build -t phovea_landing_page .` to build a Docker image.
+
+Afterwards you can push the image to our Docker registry on AWS following [this instructions](https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html).
 
 
 [phovea-image]: https://img.shields.io/badge/Phovea-DevTools-lightgrey.svg

--- a/README.md
+++ b/README.md
@@ -2,12 +2,6 @@
 
 This repository contains the Dockerfile for creating the caleydoapp.org landing page nginx server. In addition, this server also proxies to the various caleydoapp.org pages based on environment variables.
 
-***
-
-<a href="https://caleydo.org"><img src="http://caleydo.org/assets/images/logos/caleydo.svg" align="left" width="200px" hspace="10" vspace="6"></a>
-This repository is part of **[Phovea](http://phovea.caleydo.org/)**, a platform for developing web-based visualization apps. For tutorials, API docs, and more information about the build and deployment process, see the [documentation page](http://caleydo.org/documentation/).
-
-
 ## Configuration
 
 The ngnix server can be configured using environment variables (ENV).
@@ -15,7 +9,7 @@ The ngnix server can be configured using environment variables (ENV).
 
 ### Enable SSL for landing page
 
-If the variable `PHOVEA_ENABLE_SSL_LANDING_PAGE` exist a SSL certificate for caleydoapp.org is added. Default: no SSL certificate is added.
+If the variable `PHOVEA_ENABLE_SSL_LANDING_PAGE` exist a SSL certificate for caleydoapp.org is added. By default no SSL certificate is added.
 
 
 ### Add phovea app
@@ -66,6 +60,12 @@ Example: `PHOVEA_FORWARD_LINEUP=LineUp;lineup.caleydo.org;www.caleydo.org/tools/
 Run `docker build -t phovea_landing_page .` to build a Docker image.
 
 Afterwards you can push the image to our Docker registry on AWS following [this instructions](https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html).
+
+
+***
+
+<a href="https://caleydo.org"><img src="http://caleydo.org/assets/images/logos/caleydo.svg" align="left" width="200px" hspace="10" vspace="6"></a>
+This repository is part of **[Phovea](http://phovea.caleydo.org/)**, a platform for developing web-based visualization apps. For tutorials, API docs, and more information about the build and deployment process, see the [documentation page](http://caleydo.org/documentation/).
 
 
 [phovea-image]: https://img.shields.io/badge/Phovea-DevTools-lightgrey.svg

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository contains the Dockerfile for creating the caleydoapp.org landing page nginx server. In addition, this server also proxies to the various caleydoapp.org pages based on environment variables.
 
+A Docker image is available at [Docker Hub](https://hub.docker.com/r/caleydo/phovea_landing_page).
+
 ## Configuration
 
 The ngnix server can be configured using the following environment variables (ENV):
@@ -62,10 +64,7 @@ Example: `PHOVEA_FORWARD_LINEUP=LineUp;lineup.caleydo.org;www.caleydo.org/tools/
 
 ## Build Docker image
 
-Run `docker build -t phovea_landing_page .` to build a Docker image.
-
-Afterwards you can push the image to our Docker registry on AWS following [this instructions](https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html).
-
+The official [Docker image](https://hub.docker.com/r/caleydo/phovea_landing_page) is build continuously by Docker Hub. Locally you can run `docker build -t phovea_landing_page .` to build a Docker image.
 
 ***
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The ngnix server can be configured using the following environment variables (EN
 
 ### Enable SSL for landing page
 
-If the variable `PHOVEA_ENABLE_SSL_LANDING_PAGE` exist a SSL certificate for caleydoapp.org is added. By default no SSL certificate is added.
+If the variable `PHOVEA_ENABLE_SSL_LANDING_PAGE` exists a SSL certificate for caleydoapp.org is added. By default no SSL certificate is added.
 
 
 ### Add phovea app
@@ -39,7 +39,7 @@ The variable `PHOVEA_APPFORWARD_*` adds an app to the landing page only. No ngni
 
 * `<name>`: Name of the app that is visible in the landing page
 * `<domain>`: Subdomain of the app only (e.g., `lineup`)
-* `<forward>`: *Not used*
+* `<forward>`: *Not used.*
 * `<release-channel>`: Release channel can be `stable`, `daily`, or `development` and is indicated on the landing page
 
 Example: `PHOVEA_APPFORWARD_LINEUP=LineUp;lineup;cluster:12345;stable`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,8 @@ services:
     ports:
       - '80:80'
     environment:
-      - PHOVEA_APP_LINEUP=LineUp;lineup;lineup
+      - PHOVEA_APP_LINEUP=LineUp;lineup;lineup;stable
+      - PHOVEA_APPFORWARD_LINEUP=LineUp;lineup;lineup;daily
       - PHOVEA_FORWARD_LINEUP=LineUp;lineup.caleydo.org;www.caleydo.org/tools/lineup
   lineup:
     image: nginx:latest

--- a/entry_point/entry_point.sh
+++ b/entry_point/entry_point.sh
@@ -12,9 +12,14 @@ while IFS='=' read -r -d '' key value; do
     echo "Enable SSL for landing page"
     domains="$domains -d caleydoapp.org"
   fi
+  if [[ $key == PHOVEA_APPFORWARD_* ]] ; then # use APPFORWARD (without space) to avoid conflicts with the `PHOVEA_APP_*` variable
+    IFS=';'; nameAndDomainAndForward=($value); unset IFS;
+    echo "Adding application forward (landing page only): ${nameAndDomainAndForward[*]}"
+    echo $value >> /usr/share/nginx/html/apps.csv
+  fi
   if [[ $key == PHOVEA_APP_* ]] ; then
     IFS=';'; nameAndDomainAndForward=($value); unset IFS;
-    echo Adding application: ${nameAndDomainAndForward[*]}
+    echo "Adding application (landing page + SSL): ${nameAndDomainAndForward[*]}"
     echo $value >> /usr/share/nginx/html/apps.csv
     sed -e s#DOMAIN#"${nameAndDomainAndForward[1]}"#g -e s#FORWARD#"${nameAndDomainAndForward[2]}"#g /phovea/templates/caleydoapp.in.conf > /etc/nginx/conf.d/${nameAndDomainAndForward[1]}_app.conf
     cat /etc/nginx/conf.d/${nameAndDomainAndForward[1]}_app.conf
@@ -22,7 +27,7 @@ while IFS='=' read -r -d '' key value; do
   fi
   if [[ $key == PHOVEA_FORWARD_* ]] ; then
     IFS=';'; nameAndDomainAndForward=($value); unset IFS;
-    echo Adding forward: ${nameAndDomainAndForward[*]}
+    echo "Adding forward: ${nameAndDomainAndForward[*]}"
     sed -e s#DOMAIN#"${nameAndDomainAndForward[1]}"#g -e s#FORWARD#"${nameAndDomainAndForward[2]}"#g /phovea/templates/forward.in.conf > /etc/nginx/conf.d/${nameAndDomainAndForward[1]}_forward.conf
     cat /etc/nginx/conf.d/${nameAndDomainAndForward[1]}_forward.conf
   fi
@@ -83,7 +88,7 @@ EOF
   /usr/sbin/crond -f -d 8 &
 fi
 
-echo Ready
+echo "Ready"
 # Launch nginx in the foreground
 
 cat /etc/nginx/conf.d/default.conf

--- a/entry_point/entry_point.sh
+++ b/entry_point/entry_point.sh
@@ -33,7 +33,7 @@ while IFS='=' read -r -d '' key value; do
   fi
 done < <(cat /proc/self/environ)
 
-if ["$domains" = ""] ; then
+if [[ -z "$domains" ]]; then
   echo "No domains found -> skip SSL setup"
 else
   echo "Setup SSL certificates"

--- a/entry_point/entry_point.sh
+++ b/entry_point/entry_point.sh
@@ -49,7 +49,7 @@ else
   # if no landing page is set use the first app_domain
   if [[ -z "$landing_page_domain" ]]; then
     landing_page_domain=${app_domains[0]}
-    app_domains[0]="" # clear to avoid duplicates
+    unset app_domains[0] # clear to avoid duplicates
   fi
 
   # activate the ssl_certificate for the landing page in ssl.conf

--- a/entry_point/entry_point.sh
+++ b/entry_point/entry_point.sh
@@ -2,9 +2,6 @@
 
 set -euo pipefail
 
-# PHOVEA_APP_NAME=Name;domain;forward
-# PHOVEA_FORWARD_NAME=domain;forward
-# matches PHOVEA_APP_LINEUP=LineUp;lineup
 rm -rf /usr/share/nginx/html/apps.csv
 domains=""
 while IFS='=' read -r -d '' key value; do

--- a/entry_point/entry_point.sh
+++ b/entry_point/entry_point.sh
@@ -7,7 +7,10 @@ domains=""
 while IFS='=' read -r -d '' key value; do
   if [[ $key == PHOVEA_ENABLE_SSL_LANDING_PAGE ]] ; then
     echo "Enable SSL for landing page"
+    # activate the ssl_certificate for caleydoapp.org
+    sed -i 's/\#ssl_certificate/ssl_certificate/g' /etc/nginx/conf.d/ssl.conf
     domains="$domains -d caleydoapp.org"
+
   fi
   if [[ $key == PHOVEA_APPFORWARD_* ]] ; then # use APPFORWARD (without space) to avoid conflicts with the `PHOVEA_APP_*` variable
     IFS=';'; nameAndDomainAndForward=($value); unset IFS;
@@ -34,6 +37,8 @@ if [[ -z "$domains" ]]; then
   echo "No domains found -> skip SSL setup"
 else
   echo "Setup SSL certificates"
+
+
   # based on https://github.com/smashwilson/lets-nginx/blob/master/entrypoint.sh
 
   # Generate strong DH parameters for nginx, if they don't already exist.

--- a/entry_point/templates/forward.in.conf
+++ b/entry_point/templates/forward.in.conf
@@ -1,4 +1,4 @@
 server {
     server_name DOMAIN;
-    rewrite ^ http://FORWARD$1 permanent;
+    rewrite ^ https://FORWARD$1 permanent;
 }

--- a/gzip.conf
+++ b/gzip.conf
@@ -1,5 +1,5 @@
 gzip on;
 gzip_proxied no_etag;
-gzip_types text/plain text/comma-separated-values image/svg+xml text/xml text/css application/x-javascript application/javascript text/javascript application/xml  application/xml+rss text/csv application/json text/javascript application/xhtml+xml;
+gzip_types text/plain text/comma-separated-values image/svg+xml text/xml text/css application/x-javascript application/javascript text/javascript application/xml  application/xml+rss text/csv application/json application/xhtml+xml;
 gzip_vary on;
 gzip_disable "MSIE [1-6]\.(?!.*SV1)";

--- a/ssl.conf
+++ b/ssl.conf
@@ -1,7 +1,8 @@
 # Use letsEncrypt for ssl certificates
-#certificates
-ssl_certificate /etc/letsencrypt/live/caleydoapp.org/fullchain.pem;
-ssl_certificate_key /etc/letsencrypt/live/caleydoapp.org/privkey.pem;
+
+# certificates (the settings are enabled with `PHOVEA_ENABLE_SSL_LANDING_PAGE` in entry_point.sh)
+#ssl_certificate /etc/letsencrypt/live/caleydoapp.org/fullchain.pem;
+#ssl_certificate_key /etc/letsencrypt/live/caleydoapp.org/privkey.pem;
 
 # protocols
 ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # disable poodle

--- a/ssl.conf
+++ b/ssl.conf
@@ -1,8 +1,8 @@
 # Use letsEncrypt for ssl certificates
 
-# certificates (the settings are enabled with `PHOVEA_ENABLE_SSL_LANDING_PAGE` in entry_point.sh)
-#ssl_certificate /etc/letsencrypt/live/caleydoapp.org/fullchain.pem;
-#ssl_certificate_key /etc/letsencrypt/live/caleydoapp.org/privkey.pem;
+# certificates (DOMAIN is replaced in entry_point.sh)
+ssl_certificate /etc/letsencrypt/live/DOMAIN/fullchain.pem;
+ssl_certificate_key /etc/letsencrypt/live/DOMAIN/privkey.pem;
 
 # protocols
 ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # disable poodle


### PR DESCRIPTION
With the deployment of the public Ordino demo we need to introduce some additional environment variables:

* `PHOVEA_ENABLE_SSL_LANDING_PAGE`: The domain calyedoapp.org should be added on-demand.
* `PHOVEA_APPFORWARD_*`: This adds an application to the landing page, but does not setup an SSL certificate

Further changes:

* Switch to https for caleydo.org forwards