### PR TITLE
Update certbot parameters

### DIFF
--- a/entry_point/entry_point.sh
+++ b/entry_point/entry_point.sh
@@ -97,7 +97,7 @@ else
   echo "certbot certonly ${command} \
     --non-interactive \
     --force-renewal \
-    --standalone --text \
+    --standalone \
     --email ${EMAIL} \
     --agree-tos " > /etc/nginx/lets
 

--- a/entry_point/entry_point.sh
+++ b/entry_point/entry_point.sh
@@ -80,16 +80,26 @@ else
   mkdir -p /var/tmp/nginx
   chown nginx:nginx /var/tmp/nginx
 
-  # for testing add the --staging param
   echo "Landing page domain: ${landing_page_domain}"
   echo "Other domains:"
   printf '\t%s\n' "${app_domains[@]}"
 
+  # Build the certbot command
+  # domains
   command="${landing_page_domain/#/-d } ${app_domains[*]/#/-d }" # prefix with domain with `-d `
+  # non-interactive: Run without ever asking for user input
+  # force renewal: Renew certificate, even if there is one. Also implies --expand. Used instead of keep because I think the certificate is not always available in the container (e.g. when a new container is created).
+  # standalone: certbot will run a webserver
+  # email: contact info in certificate
+  # agree-tos: dont ask on stdin if we agree TOS
+  # Note: for testing add the --staging param
+  # Also see: https://certbot.eff.org/docs/using.html#certbot-command-line-options
   echo "certbot certonly ${command} \
+    --non-interactive \
+    --force-renewal \
     --standalone --text \
-    --email ${EMAIL} --agree-tos \
-    --expand " > /etc/nginx/lets
+    --email ${EMAIL} \
+    --agree-tos " > /etc/nginx/lets
 
     echo "Running initial certificate request... "
     cat /etc/nginx/lets

--- a/entry_point/entry_point.sh
+++ b/entry_point/entry_point.sh
@@ -109,11 +109,13 @@ else
   mkdir -p /etc/letsencrypt/webrootauth/
 
   # Template a cronjob to renew certificate with the webroot authenticator
+  # Certificates are checked every week and renewed if they expire in less than 30 days.
+  # See: https://certbot.eff.org/docs/using.html#renewing-certificates
   echo "Creating a cron job to keep the certificate updated"
     cat <<EOF >/etc/periodic/weekly/renew
 #!/bin/sh
-# First renew certificate, then reload nginx config
-certbot renew --webroot --webroot-path /etc/letsencrypt/webrootauth/ --post-hook "/usr/sbin/nginx -s reload"
+# First renew certificate, then reload nginx config if succesful
+certbot renew --webroot --webroot-path /etc/letsencrypt/webrootauth/ --deploy-hook "/usr/sbin/nginx -s reload"
 EOF
 
   chmod +x /etc/periodic/weekly/renew


### PR DESCRIPTION
Closes #10

For startup certificate request:
* Force-renewal of certificates on container start
* Set certbot to non-interactive mode, i.e. no user input required
* Remove unnecessary `--text` parameter

For renewal:
* replace post hook with deploy hook: nginx config is only reloaded if certificate changed.